### PR TITLE
Remove `background-color` when `bgcolor` present

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
             </style>
         <![endif]-->
     </head>
-    <body style="background-color:#E1E1E1;" bgcolor="#E1E1E1" leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
+    <body bgcolor="#E1E1E1" leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
 
         <!-- CENTER THE EMAIL // -->
         <!--
@@ -201,7 +201,7 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
                             Its width can be set to 100% for a color band
                             that spans the width of the page.
                         -->
-                        <table style="background-color:#E1E1E1;" bgcolor="#E1E1E1" border="0" cellpadding="0" cellspacing="0" width="500" id="emailHeader">
+                        <table bgcolor="#E1E1E1" border="0" cellpadding="0" cellspacing="0" width="500" id="emailHeader">
 
                             <!-- HEADER ROW // -->
                             <tr>
@@ -275,7 +275,7 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
                             Its width can be set to 100% for a color band
                             that spans the width of the page.
                         -->
-                    	<table style="background-color:#FFFFFF;" bgcolor="#FFFFFF"  border="0" cellpadding="0" cellspacing="0" width="500" id="emailBody">
+                    	<table bgcolor="#FFFFFF"  border="0" cellpadding="0" cellspacing="0" width="500" id="emailBody">
 
 
 							<!-- MODULE ROW // -->
@@ -292,7 +292,7 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
                                         tables centered in the emailBody table,
                                         in case its width is set to 100%.
                                     -->
-                                	<table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:#3498db;color:#FFFFFF;" bgcolor="#3498db">
+                                	<table border="0" cellpadding="0" cellspacing="0" width="100%" style="color:#FFFFFF;" bgcolor="#3498db">
                                     	<tr>
                                         	<td align="center" valign="top">
                                             	<!-- FLEXIBLE CONTAINER // -->
@@ -431,7 +431,7 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
 							<tr>
                             	<td align="center" valign="top">
                                 	<!-- CENTERING TABLE // -->
-                                	<table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:#F8F8F8;" bgcolor="#F8F8F8">
+                                	<table border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="#F8F8F8">
                                     	<tr>
                                         	<td align="center" valign="top">
                                             	<!-- FLEXIBLE CONTAINER // -->
@@ -1181,7 +1181,7 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
                             Its width can be set to 100% for a color band
                             that spans the width of the page.
                         -->
-                        <table style="background-color:#E1E1E1;" bgcolor="#E1E1E1" border="0" cellpadding="0" cellspacing="0" width="500" id="emailFooter">
+                        <table bgcolor="#E1E1E1" border="0" cellpadding="0" cellspacing="0" width="500" id="emailFooter">
 
                             <!-- FOOTER ROW // -->
                             <!--
@@ -1201,7 +1201,7 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
                                                         <td align="center" valign="top" width="500" class="flexibleContainerCell">
                                                             <table border="0" cellpadding="30" cellspacing="0" width="100%">
                                                                 <tr>
-                                                                    <td valign="top" style="background-color:#E1E1E1;" bgcolor="#E1E1E1">
+                                                                    <td valign="top" bgcolor="#E1E1E1">
 
                                                                         <div style="font-family:Helvetica,Arial,sans-serif;font-size:13px;color:#828282;text-align:center;line-height:120%;">
                                                                         <div>Copyright &#169; 2014 <a href="http://www.charlesmudy.com/respmail/" target="_blank" style="text-decoration:none;color:#828282;"><span style="color:#828282;">Respmail</span></a>. All&nbsp;rights&nbsp;reserved.</div>


### PR DESCRIPTION
While `background-color` has is quite reliable, HTML `bgcolor` attribute [has the best support](https://litmus.com/blog/background-colors-html-email) across the board.

This PR attempts to slightly reduce the template’s entropy by consolidating background colors into a single declaration.
